### PR TITLE
terms helper: render_term_for method

### DIFF
--- a/app/helpers/policy_manager/terms_helper.rb
+++ b/app/helpers/policy_manager/terms_helper.rb
@@ -1,10 +1,10 @@
 module PolicyManager
   module TermsHelper
 
-  	def render_term_for(policy)
-  		return if policy.nil?
-  		PolicyManager::Config.rules.find{|o| o.name == policy}.terms.published.last
-  	end
+    def render_term_for(policy)
+      return if policy.nil?
+      PolicyManager::Config.rules.find{|o| o.name == policy}.terms.published.last
+    end
 
   end
 end

--- a/app/helpers/policy_manager/terms_helper.rb
+++ b/app/helpers/policy_manager/terms_helper.rb
@@ -1,4 +1,10 @@
 module PolicyManager
   module TermsHelper
+
+  	def render_term_for(policy)
+  		return if policy.nil?
+  		PolicyManager::Config.rules.find{|o| o.name == policy}.terms.published.last
+  	end
+
   end
 end


### PR DESCRIPTION
For use this, TermsHelper must be included in ApplicationController

```ruby
helper PolicyManager::TermsHelper
```

then in your template 
```ruby
render_terms_for("age").description
``` 
will return the last published term for policy age.

