### PR TITLE
cast value with on rule setter on user behavior

### DIFF
--- a/app/models/policy_manager/concerns/user_behavior.rb
+++ b/app/models/policy_manager/concerns/user_behavior.rb
@@ -32,6 +32,7 @@ module PolicyManager::Concerns::UserBehavior
       end
 
       define_method :"#{rule_name}=" do |val=true|
+        val = ActiveRecord::Type::Boolean.new.cast(val)
         self.instance_variable_set("@#{rule_name}", val)
         ut = user_terms.new
         ut.term = policy_term_on(rule.name)


### PR DESCRIPTION
in some contexts the rule setter on user behavior can receive other kinds of boolean values. In order to fix this issue the active record bool cast enters the scene