### PR TITLE
Changed current_user to self in model helpers

### DIFF
--- a/app/models/policy_manager/concerns/user_behavior.rb
+++ b/app/models/policy_manager/concerns/user_behavior.rb
@@ -87,14 +87,14 @@ module PolicyManager::Concerns::UserBehavior
   def confirm_all_policies!
     pending_policies.each do |c|
       term = c.terms.last
-      current_user.handle_policy_for(term).accept!
+      self.handle_policy_for(term).accept!
     end
   end
 
   def reject_all_policies!
     pending_policies.each do |c|
       term = c.terms.last
-      current_user.handle_policy_for(term).reject!
+      self.handle_policy_for(term).reject!
     end
   end
 


### PR DESCRIPTION
I love this gem by the way - massive thanks for open sourcing it!

In some circles it's considered to be poor practice to use a current_user method in models ([example stack overflow answer here, but there are many more as well](https://stackoverflow.com/questions/1568218/access-to-current-user-from-within-a-model-in-ruby-on-rails?lq=1)) and it also means the helper methods don't work out of the box.

Instead, I recommend changing "current_user" to "self" which is contextually aware of the model instance making these helper methods easily used in callbacks like an "after_create" method without having to expose a current_user concept to the model.

Keen for feedback if you have any :)