### PR TITLE
Allow string to be passed into config as well as constant, default should be string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ PolicyManager::Config.setup do |c|
   # minimal exporter setup
   c.exporter = {
     path: Rails.root + "tmp/export",
-    resource: User
+    resource: 'User'
   }
 
   # portability rules, collection render. This will call a @user.articles

--- a/app/jobs/policy_manager/exporter_job.rb
+++ b/app/jobs/policy_manager/exporter_job.rb
@@ -3,7 +3,12 @@ module PolicyManager
     queue_as :default
 
     def perform(user_id)
-      user = Config.user_resource.find(user_id)
+      user_model = if Config.user_resource.is_a?(String)
+        Config.user_resource.constantize
+      else
+        Config.user_resource
+      end
+      user = user_model.find(user_id)
       Config.exporter.perform(user)
     end
   end

--- a/app/mailers/policy_manager/portability_mailer.rb
+++ b/app/mailers/policy_manager/portability_mailer.rb
@@ -3,14 +3,14 @@ module PolicyManager
 
     def progress_notification(portability_request_id)
       @portability_request = PortabilityRequest.find(portability_request_id)
-      @user = Config.user_resource.find(@portability_request.user_id)
-      
+      @user = find_user_resource(@portability_request.user_id)
+
       opts = { from: Config.from_email, to: @user.email, subject: I18n.t("terms_app.mails.progress.subject") }
       opts.merge!({
-        template_path: PolicyManager::Config.exporter.mailer_templates[:path].to_s, 
+        template_path: PolicyManager::Config.exporter.mailer_templates[:path].to_s,
         template_name: PolicyManager::Config.exporter.mailer_templates[:progress]
       }) if has_custom_template?(:progress)
-      
+
       set_mail_lang
 
       mail(opts)
@@ -18,26 +18,26 @@ module PolicyManager
 
     def completed_notification(portability_request_id)
       @portability_request = PortabilityRequest.find(portability_request_id)
-      @user = Config.user_resource.find(@portability_request.user_id)
+      @user = find_user_resource(@portability_request.user_id)
       @link = @portability_request.download_link
-      
+
       opts = { from: Config.from_email, to: @user.email, subject: I18n.t("terms_app.mails.completed.subject") }
       opts.merge!({
-        template_path: PolicyManager::Config.exporter.mailer_templates[:path].to_s, 
+        template_path: PolicyManager::Config.exporter.mailer_templates[:path].to_s,
         template_name: PolicyManager::Config.exporter.mailer_templates[:complete]
       }) if has_custom_template?(:complete)
-      
+
       set_mail_lang
 
       mail(opts)
     end
 
     def admin_notification(user_id)
-      @user = Config.user_resource.find(user_id)
-  
+      @user = find_user_resource(user_id)
+
       opts = { from: Config.from_email, to: Config.admin_email(@user), subject: I18n.t("terms_app.mails.admin.subject", email: @user.email) }
       opts.merge!({
-        template_path: PolicyManager::Config.exporter.mailer_templates[:path].to_s, 
+        template_path: PolicyManager::Config.exporter.mailer_templates[:path].to_s,
         template_name: PolicyManager::Config.exporter.mailer_templates[:admin]
       }) if has_custom_template?(:admin)
 
@@ -57,5 +57,13 @@ module PolicyManager
       PolicyManager::Config.exporter.mailer_templates[template].present? && PolicyManager::Config.exporter.mailer_templates[:path].to_s.present?
     end
 
+    def find_user_resource(user_id)
+      user_model = if Config.user_resource.is_a?(String)
+        Config.user_resource.constantize
+      else
+        Config.user_resource
+      end
+      user_model.find(user_id)
+    end
   end
 end

--- a/app/models/policy_manager/portability_request.rb
+++ b/app/models/policy_manager/portability_request.rb
@@ -5,7 +5,7 @@ module PolicyManager
   class PortabilityRequest < ApplicationRecord
     include Paperclip::Glue
 
-    belongs_to :user, class_name: Config.user_resource
+    belongs_to :user, class_name: Config.user_resource.to_s
 
     has_attached_file :attachment,
       path: Config.exporter.try(:attachment_path) || Rails.root.join("tmp/portability/:id/build.zip").to_s,

--- a/app/models/policy_manager/portability_request.rb
+++ b/app/models/policy_manager/portability_request.rb
@@ -5,10 +5,10 @@ module PolicyManager
   class PortabilityRequest < ApplicationRecord
     include Paperclip::Glue
 
-    belongs_to :user, class_name: Config.user_resource.to_s
+    belongs_to :user, class_name: Config.user_resource
 
-    has_attached_file :attachment, 
-      path: Config.exporter.try(:attachment_path) || Rails.root.join("tmp/portability/:id/build.zip").to_s, 
+    has_attached_file :attachment,
+      path: Config.exporter.try(:attachment_path) || Rails.root.join("tmp/portability/:id/build.zip").to_s,
       storage: Config.exporter.try(:attachment_storage) || :filesystem,
       s3_permissions: :private
 
@@ -41,7 +41,7 @@ module PolicyManager
     end
 
     def download_link
-      url = self.attachment.expiring_url(PolicyManager::Config.exporter.expiration_link) 
+      url = self.attachment.expiring_url(PolicyManager::Config.exporter.expiration_link)
       PolicyManager::Config.exporter.customize_link(url)
     end
 

--- a/app/models/policy_manager/user_term.rb
+++ b/app/models/policy_manager/user_term.rb
@@ -4,7 +4,7 @@ module PolicyManager
   class UserTerm < ApplicationRecord
     include AASM
 
-    belongs_to :user, class_name: Config.user_resource
+    belongs_to :user, class_name: Config.user_resource.to_s
     belongs_to :term
 
     validates_uniqueness_of :term_id, :scope => :user_id

--- a/app/models/policy_manager/user_term.rb
+++ b/app/models/policy_manager/user_term.rb
@@ -3,8 +3,8 @@ require "aasm"
 module PolicyManager
   class UserTerm < ApplicationRecord
     include AASM
-    
-    belongs_to :user, class_name: Config.user_resource.to_s
+
+    belongs_to :user, class_name: Config.user_resource
     belongs_to :term
 
     validates_uniqueness_of :term_id, :scope => :user_id

--- a/app/views/policy_manager/shared/_header.erb
+++ b/app/views/policy_manager/shared/_header.erb
@@ -8,7 +8,7 @@
       </a>
 
       <div class="d-flex order-lg-2 ml-auto">
-        
+
         <div class="dropdown">
           <a href="#" class="nav-link pr-0 leading-none" data-toggle="dropdown">
             <span class="avatar" style="background-image: url(<%= gravatar_url(controller.current_user, 40)%>)"></span>
@@ -29,14 +29,14 @@
             </a>
             <div class="dropdown-divider"></div>
             -->
-            
+
             <% if PolicyManager::Config.logout_url.present? %>
               <a class="dropdown-item" href="<%= PolicyManager::Config.logout_url %>">
                 <i class="dropdown-icon fe fe-log-out"></i>
                 <%= I18n.t("terms_app.sign_out") %>
               </a>
             <% end %>
-  
+
           </div>
         </div>
 
@@ -54,7 +54,7 @@
       <div class="col-lg order-lg-first">
 
         <ul class="nav nav-tabs border-0 flex-column flex-lg-row">
-          
+
           <% if PolicyManager::Config.is_admin?(controller.current_user) %>
 
             <li class="nav-item">
@@ -73,7 +73,7 @@
 
           <% end %>
 
-          <% if controller.current_user.class.to_s == PolicyManager::Config.user_resource.to_s %>
+          <% if controller.current_user.class.to_s == PolicyManager::Config.user_resource %>
 
             <li class="separator"></li>
 

--- a/app/views/policy_manager/shared/_header.erb
+++ b/app/views/policy_manager/shared/_header.erb
@@ -73,7 +73,7 @@
 
           <% end %>
 
-          <% if controller.current_user.class.to_s == PolicyManager::Config.user_resource %>
+          <% if controller.current_user.class.to_s == PolicyManager::Config.user_resource.to_s %>
 
             <li class="separator"></li>
 

--- a/lib/policy_manager/config.rb
+++ b/lib/policy_manager/config.rb
@@ -21,8 +21,8 @@ module PolicyManager
       yield self
 
       # sets this defaults after configuration
-      @@user_resource ||= User
-      @@admin_user_resource ||= User
+      @@user_resource ||= 'User'
+      @@admin_user_resource ||= 'User'
 
       self
     end
@@ -45,7 +45,7 @@ module PolicyManager
         user.is_a? admin_user_resource
       else
         raise Rails.logger.error("GDPR ERROR! please add is_admin_method to your gdpr initializer") if @@is_admin_method.blank?
-        @@is_admin_method.call(user) 
+        @@is_admin_method.call(user)
       end
     end
 

--- a/lib/policy_manager/exporter.rb
+++ b/lib/policy_manager/exporter.rb
@@ -2,14 +2,14 @@ require "fileutils"
 
 module PolicyManager
   class Exporter
-    attr_accessor :path, 
-                  :resource, 
-                  :index_template, 
-                  :layout, 
-                  :after_zip, 
-                  :mail_helpers, 
+    attr_accessor :path,
+                  :resource,
+                  :index_template,
+                  :layout,
+                  :after_zip,
+                  :mail_helpers,
                   :attachment_path,
-                  :attachment_storage, 
+                  :attachment_storage,
                   :expiration_link,
                   :customize_link,
                   :mailer_templates,
@@ -61,7 +61,7 @@ module PolicyManager
 
     def handled_template(template)
       return if template.blank?
-      if template.is_a?(String) 
+      if template.is_a?(String)
         template
       elsif template.is_a?(Pathname)
         File.open(template).read

--- a/lib/policy_manager/exporter/handler.rb
+++ b/lib/policy_manager/exporter/handler.rb
@@ -7,7 +7,11 @@ module PolicyManager
 
     def initialize(opts={})
       self.path = opts[:path]
-      self.resource = opts[:resource]
+      self.resource = if opts[:resource].is_a?(String)
+        opts[:resource].constantize
+      else
+        opts[:resource]
+      end
       self.after_zip = opts[:after_zip] if opts[:after_zip]
     end
 
@@ -68,20 +72,20 @@ module PolicyManager
       base_dir = self.base_path.join(rule.name)
       FileUtils.mkdir_p(base_dir)
       resource_path = base_dir.join("index.html")
-      
+
       view = ExporterView.new({
-        assigns: {member: o}, 
-        build_path: self.base_path, 
-        base_path: resource_path, 
-        template: rule.template, 
+        assigns: {member: o},
+        build_path: self.base_path,
+        base_path: resource_path,
+        template: rule.template,
         rule: rule
       }).save(resource_path)
 
       puts "saving at #{self.path.join rule.name}"
-      
+
       json = JsonExporterView.new({
-        assigns: {member: o}, 
-        template: rule.json_template, 
+        assigns: {member: o},
+        template: rule.json_template,
         folder: base_dir
       }).save if rule.json_template.present?
     end
@@ -93,26 +97,26 @@ module PolicyManager
       base_dir  = self.base_path.join(rule.name)
       FileUtils.mkdir_p(base_dir)
 
-      (1..o.total_pages).to_a.each do |i| 
+      (1..o.total_pages).to_a.each do |i|
         o = resource.portability_collection_for(rule, i)
 
         page_name = i
         folder_dir = page_name == 1 ? base_dir : base_dir.join(page_name.to_s)
         FileUtils.mkdir_p(folder_dir)
         resource_path = folder_dir.join("index.html")
-        
+
         view = ExporterView.new({
-          assigns: {collection: o} , 
-          build_path: self.base_path, 
-          base_path: resource_path, 
-          template: rule.template, 
+          assigns: {collection: o} ,
+          build_path: self.base_path,
+          base_path: resource_path,
+          template: rule.template,
           rule: rule
         }).save(resource_path)
 
-        
+
         json = JsonExporterView.new({
-          assigns: {collection: o}, 
-          template: rule.json_template, 
+          assigns: {collection: o},
+          template: rule.json_template,
           folder: folder_dir
         }).save if rule.json_template.present?
 
@@ -123,12 +127,12 @@ module PolicyManager
     def render_index
       resource_path = self.base_path.join("index.html")
       template = PolicyManager::Config.exporter.index_template
-      view = ExporterView.new({ 
+      view = ExporterView.new({
         assigns: {
           collection: PolicyManager::Config.portability_rules
-        }, 
-        build_path: self.base_path, 
-        base_path: resource_path, 
+        },
+        build_path: self.base_path,
+        base_path: resource_path,
         template: template
       }).save( resource_path )
       puts "saving at #{resource_path}"

--- a/spec/controllers/policy_manager/portability_requests_controller_spec.rb
+++ b/spec/controllers/policy_manager/portability_requests_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-module PolicyManager 
+module PolicyManager
   describe PortabilityRequestsController do
 
     routes { PolicyManager::Engine.routes }
@@ -9,17 +9,17 @@ module PolicyManager
 
       @config = PolicyManager::Config.setup do |c|
         c.is_admin_method = ->(o){true}
-        c.user_resource = User
+        c.user_resource = 'User'
         c.from_email = "admin@acme.com"
         c.admin_email_inbox = "admin@acme.com"
-        c.add_rule({name: "age", 
+        c.add_rule({name: "age",
           validates_on: [:create, :update],
-          blocking: true, 
-          if: ->(o){ o.enabled_for_validation } 
+          blocking: true,
+          if: ->(o){ o.enabled_for_validation }
         })
         c.exporter = {
           path: Rails.root + "tmp/export",
-          resource: User
+          resource: 'User'
         }
       end
 

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,11 +1,40 @@
+# SQLite version 3.x
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+#
 default: &default
   adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
-
 test:
   adapter: mysql2
-  database: myapp_test
+  database: gdpr_test
+  host: "localhost"
   username: root
+  password:
+  reconnect: true
+  port: 3306
   encoding: utf8
+
+
+testSQLITE:
+  <<: *default
+  database: db/test.sqlite3
+
+development:
+  <<: *default
+  database: db/development.sqlite3
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+testsqlite:
+  <<: *default
+  database: db/test.sqlite3
+
+production:
+  <<: *default
+  database: db/production.sqlite3

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,40 +1,11 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
   adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
+
 test:
   adapter: mysql2
-  database: gdpr_test
-  host: "localhost"
+  database: myapp_test
   username: root
-  password: 
-  reconnect: true
-  port: 3306
   encoding: utf8
-
-
-testSQLITE:
-  <<: *default
-  database: db/test.sqlite3
-
-development:
-  <<: *default
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-testsqlite:
-  <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3

--- a/spec/models/policy_manager/exporter_spec.rb
+++ b/spec/models/policy_manager/exporter_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 require 'ostruct'
 
 describe PolicyManager::Exporter do
-    
+
   before(:each) do
     PolicyManager::Term.create(description: "el", rule: "age")
 
     @config = PolicyManager::Config.setup do |c|
-      c.add_rule({name: "age", validates_on: [:create, :update], 
+      c.add_rule({name: "age", validates_on: [:create, :update],
                   if: ->(o){ o.enabled_for_validation } })
-      c.exporter = { 
-        path: Rails.root + "tmp/export", 
-        resource: User ,
+      c.exporter = {
+        path: Rails.root + "tmp/export",
+        resource: 'User' ,
         index_template: '<h1>index template, custom</h1>
                         <ul>
                           <% @collection.each do |rule| %>
@@ -24,8 +24,8 @@ describe PolicyManager::Exporter do
       }
 
       c.add_portability_rule({
-        name: "exportable_data", 
-        collection: :foo_data, 
+        name: "exportable_data",
+        collection: :foo_data,
         template: "hellow , here a collection will be rendered
         <%= @base_path %>
          <% @collection.each do |item| %>
@@ -38,13 +38,13 @@ describe PolicyManager::Exporter do
       })
 
       c.add_portability_rule({
-        name: "my_account", 
+        name: "my_account",
         member: :account_data,
-        template: "hellow , here a resource will be rendered <%= image_tag(@member[:image]) %> <%= @member[:name] %> "          
+        template: "hellow , here a resource will be rendered <%= image_tag(@member[:image]) %> <%= @member[:name] %> "
       })
 
       c.add_portability_rule({
-        name: "my_account_from_template", 
+        name: "my_account_from_template",
         member: :account_data,
         template: Rails.root.join("app/views").join("template.erb")
       })
@@ -76,10 +76,10 @@ describe PolicyManager::Exporter do
     user = User.create(email: "a@a.cl")
     assert !user.errors.any?
     PolicyManager::ExporterHandler.any_instance.stubs(:clear!).returns(true)
-      
+
     PolicyManager::ExporterHandler.any_instance.stubs(:handle_zip_upload).returns(true)
     @config.exporter.perform(user)
-  
+
     assert File.exists?(Rails.root.join("tmp/export/#{user.id}"))
     paths = Dir.glob( Rails.root.join("tmp/export/#{user.id}") + "*")
     names = paths.map{|o| File.basename(o) }
@@ -91,8 +91,8 @@ describe PolicyManager::Exporter do
 
     FileUtils.rm_rf(Rails.root.join("tmp/export/#{user.id}"))
     FileUtils.rm_rf(Rails.root.join("tmp/export/#{user.id}-out.zip"))
-  
- 
+
+
   end
 
 end

--- a/spec/models/policy_manager/portability_request_spec.rb
+++ b/spec/models/policy_manager/portability_request_spec.rb
@@ -10,9 +10,9 @@ describe PolicyManager::PortabilityRequest do
         c.from_email = "foo@bar.org"
         c.admin_email_inbox = "foo@baaz.org"
         c.add_rule({name: "age", validates_on: [:create, :update], if: ->(o){ o.enabled_for_validation } })
-        c.exporter = { 
-          path: Rails.root + "tmp/export", 
-          resource: User ,
+        c.exporter = {
+          path: Rails.root + "tmp/export",
+          resource: 'User' ,
           index_template: '
           <h1>index template, custom</h1>
                           <ul>
@@ -21,17 +21,17 @@ describe PolicyManager::PortabilityRequest do
                             <% end %>
                           </ul>',
           layout: 'portability_requests',
-          after_zip: ->(zip_path, resource){ 
-            puts "THIS IS GREAT #{zip_path} was zipped, now what ??" 
+          after_zip: ->(zip_path, resource){
+            puts "THIS IS GREAT #{zip_path} was zipped, now what ??"
           }
 
         }
 
         c.add_portability_rule({
-          name: "exportable_data", 
-          collection: :foo_data, 
-          template: "hello , here a collection will be 
-          rendered <%= @collection.to_json %> 
+          name: "exportable_data",
+          collection: :foo_data,
+          template: "hello , here a collection will be
+          rendered <%= @collection.to_json %>
           <%= will_paginate(@collection, renderer: PolicyManager::PaginatorRenderer) %>",
           per: 10
         })
@@ -43,8 +43,8 @@ describe PolicyManager::PortabilityRequest do
 
     it "user export will generate folder, layout, templates" do
 
-      User.any_instance.stubs(:enabled_for_validation).returns(false) 
-        User.any_instance.stubs(:foo_data).returns( (1..100).to_a) 
+      User.any_instance.stubs(:enabled_for_validation).returns(false)
+        User.any_instance.stubs(:foo_data).returns( (1..100).to_a)
           user = User.create(email: "a@a.cl")
           assert !user.errors.any?
           preq = user.portability_requests.create
@@ -64,7 +64,7 @@ describe PolicyManager::PortabilityRequest do
           noko = Nokogiri::HTML.parse( File.open(paths.first + "/index.html").read )
           assert noko.css("h1").text == "layout header"
           assert noko.css("footer").text == "layout footer"
-    
+
           expect(preq.reload).to be_completed
 
           notification = ActionMailer::Base.deliveries.last
@@ -72,7 +72,7 @@ describe PolicyManager::PortabilityRequest do
 
           FileUtils.rm_rf(Rails.root.join("tmp/export/#{user.id}"))
           FileUtils.rm_rf(Rails.root.join("tmp/export/#{user.id}-out.zip"))
-    
+
     end
 
 end


### PR DESCRIPTION
Fixes: https://github.com/prey/gdpr_rails/issues/31

We should not load the constant directly in the initializer as this can break other dependencies.

Discussed in detail here: https://github.com/rails/rails/issues/32933#issuecomment-395919084