### PR TITLE
Contribution Documentation + Ruby 2.6.4 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
     gemfile: gemfiles/rails_5.2.3.gemfile
   - rvm: 2.5.1
     gemfile: gemfiles/rails_6.gemfile
+  - rvm: 2.6.4
+    gemfile: gemfiles/rails_6.gemfile
 
 
 script: COVERALLS_REPO_TOKEN=bPQteZngJWF84BYuws90hMmXwWYcMpV9S bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -329,7 +329,10 @@ portability_request         DELETE /portability_requests/:id(.:format)          
 + Patricio Jofré - pato@preyhq.com
 
 ## Contributing
-just fork the repo and send us a Pull Request, with some tests please :)
+- Just fork the repo and send us a Pull Request, with some tests please :)
+- FYI: The CI pipeline on travis will require gemlocks for each or the Rails versions we test against.
+  - Run `bundle exec appraisal install` and commit the generated files in the `./gemfile/` directory
+  - Check out [Appraisal](https://github.com/thoughtbot/appraisal) for more context.
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
Hello @michelson 

Quick documentation update for future contributors based on feedback in #46 & #45 

- Updated contribution documentation
- Added ruby 2.6.4 to travis pipelines matrix for Rails 6

Thanks for the project 🎉 

----
Addition reads as follows:

## Contributing
- Just fork the repo and send us a Pull Request, with some tests please :)
- FYI: The CI pipeline on travis will require gemlocks for each or the Rails versions we test against.
  - Run `bundle exec appraisal install` and commit the generated files in the `./gemfile/` directory
  - Check out [Appraisal](https://github.com/thoughtbot/appraisal) for more context.
